### PR TITLE
Allow BM Extender to be used with custom hostnames.

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -18,10 +18,10 @@
     },
     "content_scripts": [{
         "run_at": "document_end",
-        "matches": ["*://*.commercecloud.salesforce.com/*", "*://*.demandware.com/*", "*://*.demandware.net/*"],
+        "matches": ["*://*/on/demandware.store/Sites-Site/*", "*://*.commercecloud.salesforce.com/*", "*://*.demandware.com/*", "*://*.demandware.net/*"],
         "js": ["jquery.js", "dotjs.js"]
     }],
     "options_page": "options/options.html",
-    "permissions" : ["activeTab", "*://*.commercecloud.salesforce.com/*", "*://*.demandware.com/*", "*://*.demandware.net/*", "storage"],
+    "permissions" : ["activeTab", "*://*/on/demandware.store/Sites-Site/*", "*://*.commercecloud.salesforce.com/*", "*://*.demandware.com/*", "*://*.demandware.net/*", "storage"],
     "web_accessible_resources": ["scripts/*.js", "styles/*.css"]
 }

--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -68,7 +68,7 @@
     });
 
     function isDWUrl(url) {
-        return url.indexOf('.demandware.net/') > -1;
+        return location.pathname.indexOf('on/demandware.store/Sites-Site') > -1;
     }
 
     function renderLogsList() {


### PR DESCRIPTION
Our organization recently added a custom hostname to our staging instance for easier previewing of SEO URLs.  Unfortunately, that meant that the extension no longer would activate in our Business Manager!  Our Content Team was sad.

Then I found that your plugin was open source!  So I opened it up to see what I could do.

This just allows the activation of the plugin to key off of the demandware path of the URL instead of the hostname, so that the hostname no longer matters.

Thanks for your work!